### PR TITLE
Create pull_request_template.md

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/pull_request_template.md
+++ b/.github/PULL_REQUEST_TEMPLATE/pull_request_template.md
@@ -1,0 +1,19 @@
+_Before you submit this PR: make sure to put all operations-related information in a wiki-note, a PR should be about code and is publicly accessible_
+
+## What does the code in this PR do / what does it improve?
+
+## Can you briefly describe how it works?
+
+## Can you give a minimal working example (or illustrate with a figure)?
+
+_Please include the following if applicable:_
+  - [ ] _Update the docstring(s)_
+  - [ ] _Update the documentation_
+  - [ ] _Tests to check the (new) code is working as desired._
+  - [ ] _Does it solve one of the open issues on github?_
+
+### _Notes on testing_
+ - _Until the automated tests pass, please mark the PR as a draft._
+ - _On the XENONnT fork we test with database access, on private forks there is no database access for security considerations._
+
+All _italic_ comments can be removed from this template.


### PR DESCRIPTION
Previously the [naming is messed up](https://github.com/FaroutYLq/saltax/blob/main/.github/pull_request_templates.md) for the PR template, so it is not working. Now it is fixed. 