### PR TITLE
Default `cmt_version` downgrade

### DIFF
--- a/saltax/contexts.py
+++ b/saltax/contexts.py
@@ -147,7 +147,6 @@ def sxenonnt(saltax_mode,
              auto_register=True,
              faxconf_version="sr0_v4",
              cmt_version="global_v9",
-             wfsim_registry='RawRecordsFromFaxNT',
              cmt_run_id="026000",
              **kwargs):
     assert saltax_mode in SALTAX_MODES, "saltax_mode must be one of %s"%(SALTAX_MODES)
@@ -164,7 +163,6 @@ def sxenonnt(saltax_mode,
             output_folder=output_folder,
             faxconf_version=faxconf_version,
             cmt_version=cmt_version,
-            wfsim_registry=wfsim_registry,
             cmt_run_id=cmt_run_id,
             cut_list=cut_list,
             **kwargs)

--- a/saltax/contexts.py
+++ b/saltax/contexts.py
@@ -56,7 +56,7 @@ def xenonnt_salted(output_folder='./strax_data',
                    cut_list=BasicCuts, 
                    auto_register=True,
                    faxconf_version="sr0_v4",
-                   cmt_version="global_v11",
+                   cmt_version="global_v9",
                    cmt_run_id="026000",
                    **kwargs):
     # Based on cutax.xenonnt_sim_base()
@@ -146,7 +146,7 @@ def sxenonnt(saltax_mode,
              cut_list=BasicCuts, 
              auto_register=True,
              faxconf_version="sr0_v4",
-             cmt_version="global_v11",
+             cmt_version="global_v9",
              wfsim_registry='RawRecordsFromFaxNT',
              cmt_run_id="026000",
              **kwargs):


### PR DESCRIPTION
_Before you submit this PR: make sure to put all operations-related information in a wiki-note, a PR should be about code and is publicly accessible_

## What does the code in this PR do / what does it improve?
- Downgraded `cmt_version` in `sxenonnt` so that we won't trigger bug.
- Removed useless `wfsim_registry`

## Can you briefly describe how it works?

## Can you give a minimal working example (or illustrate with a figure)?

_Please include the following if applicable:_
  - [x] _Add an appropriate tag to this PR_
  - [ ] _Update the docstring(s)_
  - [ ] _Update the documentation_
  - [ ] _Tests to check the (new) code is working as desired._
  - [ ] _Does it solve one of the open issues on github?_

### _Notes on testing_
 - _Until the automated tests pass, please mark the PR as a draft._
 - _On the XENONnT fork we test with database access, on private forks there is no database access for security considerations._

All _italic_ comments can be removed from this template.
