### PR TITLE
Debug sxenonnt in salt mode

### DIFF
--- a/saltax/contexts.py
+++ b/saltax/contexts.py
@@ -19,7 +19,9 @@ SXNT_COMMON_OPTS_REGISTER = [saltax.SPulseProcessing,
 XNT_COMMON_OPTS_OVERRIDE = dict(
     register=SXNT_COMMON_OPTS_REGISTER,
 )
-SXNT_COMMON_OPTS = XNT_COMMON_OPTS.update(XNT_COMMON_OPTS_OVERRIDE)
+SXNT_COMMON_OPTS = XNT_COMMON_OPTS.copy()
+SXNT_COMMON_OPTS['register'] = XNT_COMMON_OPTS_OVERRIDE['register']
+
 
 # saltax configuration overrides
 SCHANNEL_STARTS_AT = -494
@@ -40,7 +42,8 @@ XNT_COMMON_CONFIG_OVERRIDE = dict(
         nveto_blank=(2999, 2999)
     ),
 )
-SXNT_COMMON_CONFIG = XNT_COMMON_CONFIG.update(XNT_COMMON_CONFIG_OVERRIDE)
+SXNT_COMMON_CONFIG = XNT_COMMON_CONFIG.copy()
+SXNT_COMMON_CONFIG['channel_map'] = XNT_COMMON_CONFIG_OVERRIDE['channel_map']
 
 # saltax modes supported
 SALTAX_MODES = ['data', 'simu', 'salt']
@@ -76,10 +79,10 @@ def xenonnt_salted(output_folder='./strax_data',
     fax_conf='fax_config_nt_{:s}.json'.format(faxconf_version)
 
     # Based on straxen.contexts.xenonnt_online()
-    context_options = dict(
-        **SXNT_COMMON_OPTS,
-        **kwargs,
-    )
+    if kwargs is not None:
+        context_options = dict(**SXNT_COMMON_OPTS, **kwargs)
+    else:
+        context_options = SXNT_COMMON_OPTS.copy()
     context_config = dict(
         detector='XENONnT', # from straxen.contexts.xenonnt_simulation()
         fax_config=fax_conf, # from straxen.contexts.xenonnt_simulation()

--- a/saltax/contexts.py
+++ b/saltax/contexts.py
@@ -97,7 +97,7 @@ def xenonnt_salted(output_folder='./strax_data',
     st.deregister_plugins_with_missing_dependencies()
         
     # Based on straxen.contexts.xenonnt()
-    st.apply_cmt_version(cmt_version)
+    #st.apply_cmt_version(cmt_version)
     if xedocs_version is not None:
         st.apply_xedocs_configs(version=xedocs_version, **kwargs)
     
@@ -129,7 +129,7 @@ def xenonnt_salted(output_folder='./strax_data',
                    for key, val in cmt_options_full.items()}
     # First, fix gain model for simulation
     st.set_config({'gain_model_mc': 
-                        ('cmt_run_id', cmt_run_id, *cmt_options['gain_model'])})
+                        ('cmt_run_id', cmt_run_id, "legacy-to-pe://to_pe_placeholder")})
     fax_config_override_from_cmt = dict()
     for fax_field, cmt_field in _config_overlap.items():
         value = cmt_options[cmt_field]

--- a/saltax/contexts.py
+++ b/saltax/contexts.py
@@ -69,9 +69,9 @@ def xenonnt_salted(output_folder='./strax_data',
     :param xedocs_version: XENONnT documentation version to use, defaults to DEFAULT_XEDOCS_VERSION
     :param cut_list: Cut list to use, defaults to BasicCuts
     :param auto_register: Whether to automatically register cuts, defaults to True
-    :param faxconf_version: fax configuration version to use, defaults to "sr0_v4"
-    :param cmt_version: CMT version to use, defaults to "global_v9"
-    :param cmt_run_id: CMT run ID to use, defaults to "026000"
+    :param faxconf_version: (for simulation) fax configuration version to use, defaults to "sr0_v4"
+    :param cmt_version: (for simulation) CMT version to use, defaults to "global_v9"
+    :param cmt_run_id: (for simulation) CMT run ID to use, defaults to "026000"
     :param kwargs: Extra options to pass to strax.Context
     :return: strax context
     """


### PR DESCRIPTION
_Before you submit this PR: make sure to put all operations-related information in a wiki-note, a PR should be about code and is publicly accessible_

## What does the code in this PR do / what does it improve?
Debugged `sxenonnt('salt')`

## Can you briefly describe how it works?
- Fixed dictionary bug in `update`
- added placeholder for `gain_model_mc`

## Can you give a minimal working example (or illustrate with a figure)?
```python
st = saltax.contexts.sxenonnt('salt')
st.config

{'detector': 'XENONnT',
 'fax_config': 'fax_config_nt_sr0_v4.json',
 'check_raw_record_overlaps': True,
 'n_tpc_pmts': 494,
 'n_top_pmts': 253,
 'gain_model': '[list-to-array://xedocs://pmt_area_to_pes?as_list=True&sort=pmt&detector=tpc&run_id=plugin.run_id&version=v9&attr=value](list-to-array://xedocs//pmt_area_to_pes?as_list=True&sort=pmt&detector=tpc&run_id=plugin.run_id&version=v9&attr=value)',
 'gain_model_nv': 'cmt://to_pe_model_nv?run_id=026000&version=v4',
 'gain_model_mv': 'cmt://to_pe_model_mv?run_id=026000&version=v1',
 'channel_map': immutabledict({'stpc': (-494, -1), 'tpc': (0, 493), 'he': (500, 752), 'aqmon': (790, 807), 'aqmon_nv': (808, 815), 'tpc_blank': (999, 999), 'mv': (1000, 1083), 'aux_mv': (1084, 1087), 'mv_blank': (1999, 1999), 'nveto': (2000, 2119), 'nveto_blank': (2999, 2999)}),
 'fdc_map': 'itp_[map://resource://format://xedocs://fdc_maps?algorithm=plugin.default_reconstruction_algorithm&fmt=binary&attr=value&run_id=plugin.run_id&version=v6&scale_coordinates=plugin.coordinate_scales](map://resource//format://xedocs://fdc_maps?algorithm=plugin.default_reconstruction_algorithm&fmt=binary&attr=value&run_id=plugin.run_id&version=v6&scale_coordinates=plugin.coordinate_scales)',
 'z_bias_map': 'itp_[map://resource://XnT_z_bias_map_chargeup_20230329.json.gz?fmt=json.gz&method=RegularGridInterpolator](map://resource//XnT_z_bias_map_chargeup_20230329.json.gz?fmt=json.gz&method=RegularGridInterpolator)',
 'avg_se_gain': 'cmt://avg_se_gain?run_id=026000&version=v1',
 'baseline_samples_nv': 'cmt://baseline_samples_nv?run_id=026000&version=v1',
 'bayes_config_file': '[resource://cmt://bayes_model?fmt=npy&run_id=026000&version=v2](resource://cmt//bayes_model?fmt=npy&run_id=026000&version=v2)',
 'diffusion_constant': 'cmt://electron_diffusion_cte?run_id=026000&version=v1',
 'electron_drift_time_gate': 'cmt://electron_drift_time_gate?run_id=026000&version=v2',
 'electron_drift_velocity': 'cmt://electron_drift_velocity?run_id=026000&version=v3',
 'elife': 'cmt://elife?run_id=026000&version=v6',
 'hit_min_amplitude': 'cmt://hit_thresholds_tpc?run_id=026000&version=v1',
 'hit_min_amplitude_he': 'cmt://hit_thresholds_he?run_id=026000&version=v1',
 'hit_min_amplitude_mv': 'cmt://hit_thresholds_mv?run_id=026000&version=v1',
 'hit_min_amplitude_nv': 'cmt://hit_thresholds_nv?run_id=026000&version=v1',
 'rel_extraction_eff': 'cmt://rel_extraction_eff?run_id=026000&version=v3',
 'rel_light_yield': 'cmt://relative_light_yield?run_id=026000&version=v1',
 's1_aft_map': 'itp_[map://resource://cmt://s1_aft_xyz_map?fmt=json&run_id=026000&version=v4](map://resource//cmt://s1_aft_xyz_map?fmt=json&run_id=026000&version=v4)',
 's1_xyz_map': 'itp_[map://resource://cmt://format://s1_xyz_map_{algo}?algo=plugin.default_reconstruction_algorithm&fmt=json&run_id=026000&version=v5](map://resource//cmt://format://s1_xyz_map_%7Balgo%7D?algo=plugin.default_reconstruction_algorithm&fmt=json&run_id=026000&version=v5)',
 's2_xy_map': 'itp_[map://resource://cmt://format://s2_xy_map_{algo}?algo=plugin.default_reconstruction_algorithm&fmt=json&run_id=026000&version=v5](map://resource//cmt://format://s2_xy_map_%7Balgo%7D?algo=plugin.default_reconstruction_algorithm&fmt=json&run_id=026000&version=v5)',
 'se_gain': 'cmt://se_gain?run_id=026000&version=v3',
 'tf_event_model_cnn': 'tf://[resource://cmt://cnn_model?fmt=abs_path&run_id=026000&version=v6](resource://cmt//cnn_model?fmt=abs_path&run_id=026000&version=v6)',
 'tf_event_model_gcn': 'tf://[resource://cmt://gcn_model?fmt=abs_path&run_id=026000&version=v6](resource://cmt//gcn_model?fmt=abs_path&run_id=026000&version=v6)',
 'tf_event_model_mlp': 'tf://[resource://cmt://mlp_model?fmt=abs_path&run_id=026000&version=v6](resource://cmt//mlp_model?fmt=abs_path&run_id=026000&version=v6)',
 'tf_model_cnn': 'tf://[resource://cmt://cnn_model?fmt=abs_path&run_id=026000&version=v6](resource://cmt//cnn_model?fmt=abs_path&run_id=026000&version=v6)',
 'tf_model_gcn': 'tf://[resource://cmt://gcn_model?fmt=abs_path&run_id=026000&version=v6](resource://cmt//gcn_model?fmt=abs_path&run_id=026000&version=v6)',
 'tf_model_mlp': 'tf://[resource://cmt://mlp_model?fmt=abs_path&run_id=026000&version=v6](resource://cmt//mlp_model?fmt=abs_path&run_id=026000&version=v6)',
 'event_info_function': 'blinding_v11',
 'g1': 'bodega://g1?bodega_version=v5',
 'g2': 'bodega://g2?bodega_version=v5',
 'gain_model_mc': 'cmt://to_pe_model?run_id=026000&version=v6',
 's2_secondary_sc_gain': 'cmt://se_gain?run_id=026000&version=v3',
 'fax_config_override_from_cmt': {'drift_time_gate': ('cmt_run_id',
   '026000',
   'electron_drift_time_gate',
   'v2',
   True),
  'drift_velocity_liquid': ('cmt_run_id',
   '026000',
   'electron_drift_velocity',
   'v3',
   True),
  'electron_lifetime_liquid': ('cmt_run_id', '026000', 'elife', 'v6', True)}}
```

_Please include the following if applicable:_
  - [x] _Add an appropriate tag to this PR_
  - [ ] _Update the docstring(s)_
  - [ ] _Update the documentation_
  - [ ] _Tests to check the (new) code is working as desired._
  - [ ] _Does it solve one of the open issues on github?_

### _Notes on testing_
 - _Until the automated tests pass, please mark the PR as a draft._
 - _On the XENONnT fork we test with database access, on private forks there is no database access for security considerations._

All _italic_ comments can be removed from this template.
