### PR TITLE
Added safeguard in chunk timing range

### DIFF
--- a/saltax/plugins/s_raw_records.py
+++ b/saltax/plugins/s_raw_records.py
@@ -11,6 +11,8 @@ logging.basicConfig(handlers=[logging.StreamHandler()])
 log = logging.getLogger('wfsim.interface')
 log.setLevel('WARNING')
 
+NS_NO_INSTRUCTION_BEFORE_CHUNK_END = 5e7
+
 @export
 class ChunkRawRecords(object):
     """
@@ -228,7 +230,7 @@ class SRawRecordsFromFaxNT(SimulatorPlugin):
         self.sim = ChunkRawRecords(self.config)
         instructions = self.instructions
         instructions = instructions[(instructions['time'] >= start) & 
-                                    (instructions['time'] < end)] # Probably need safeguard here
+                                    (instructions['time'] < end-NS_NO_INSTRUCTION_BEFORE_CHUNK_END)]
         self.sim_iter = self.sim(instructions)
         try:
             result = next(self.sim_iter)


### PR DESCRIPTION
_Before you submit this PR: make sure to put all operations-related information in a wiki-note, a PR should be about code and is publicly accessible_

## What does the code in this PR do / what does it improve?
Added safeguard in chunk timing range so we don't explode the last chunk time range.

## Can you briefly describe how it works?
Hardcoded: `NS_NO_INSTRUCTION_BEFORE_CHUNK_END = 5e7`

## Can you give a minimal working example (or illustrate with a figure)?

_Please include the following if applicable:_
  - [ ] _Add an appropriate tag to this PR_
  - [ ] _Update the docstring(s)_
  - [ ] _Update the documentation_
  - [ ] _Tests to check the (new) code is working as desired._
  - [ ] _Does it solve one of the open issues on github?_

### _Notes on testing_
 - _Until the automated tests pass, please mark the PR as a draft._
 - _On the XENONnT fork we test with database access, on private forks there is no database access for security considerations._

All _italic_ comments can be removed from this template.
