### PR TITLE
Hitlets boundary

### DIFF
--- a/saltax/plugins/s_peaklets.py
+++ b/saltax/plugins/s_peaklets.py
@@ -272,9 +272,13 @@ class SPeaklets(strax.Plugin):
         hitlets = hits
         del hits
 
+        # Extend hits into hitlets and clip at chunk boundaries:
         hitlets['time'] -= (hitlets['left'] - hitlets['left_integration']) * hitlets['dt']
         hitlets['length'] = hitlets['right_integration'] - hitlets['left_integration']
+
         hitlets = strax.sort_by_time(hitlets)
+        hitlets_time = np.copy(hitlets["time"])
+        self.clip_peaklet_times(hitlets, start, end)
         rlinks = strax.record_links(records)
 
         # If sum_waveform_top_array is false, don't digitize the top array
@@ -319,15 +323,17 @@ class SPeaklets(strax.Plugin):
             # Compute the width again for corrected peaks
             strax.compute_widths(peaklets, select_peaks_indices=peak_list)
 
-        hitlet_time_shift = (hitlets['left'] - hitlets['left_integration']) * hitlets['dt']
-        hit_max_times = hitlets['time'] + hitlet_time_shift  # add time shift again to get correct maximum
-        hit_max_times += hitlets['dt'] * hit_max_sample(records, hitlets)
-
         # Compute tight coincidence level.
         # Making this a separate plugin would
         # (a) doing hitfinding yet again (or storing hits)
         # (b) increase strax memory usage / max_messages,
         #     possibly due to its currently primitive scheduling.
+        hitlet_time_shift = (hitlets['left'] - hitlets['left_integration']) * hitlets['dt']
+        hit_max_times = (
+            hitlets['time'] + hitlet_time_shift
+        )  # add time shift again to get correct maximum
+        hit_max_times += hitlets['dt'] * hit_max_sample(records, hitlets)
+
         hit_max_times_argsort = np.argsort(hit_max_times)
         sorted_hit_max_times = hit_max_times[hit_max_times_argsort]
         sorted_hit_channels = hitlets['channel'][hit_max_times_argsort]

--- a/saltax/plugins/s_peaklets.py
+++ b/saltax/plugins/s_peaklets.py
@@ -330,7 +330,7 @@ class SPeaklets(strax.Plugin):
         #     possibly due to its currently primitive scheduling.
         hitlet_time_shift = (hitlets['left'] - hitlets['left_integration']) * hitlets['dt']
         hit_max_times = (
-            hitlets['time'] + hitlet_time_shift
+            hitlets_time + hitlet_time_shift
         )  # add time shift again to get correct maximum
         hit_max_times += hitlets['dt'] * hit_max_sample(records, hitlets)
 


### PR DESCRIPTION
_Before you submit this PR: make sure to put all operations-related information in a wiki-note, a PR should be about code and is publicly accessible_

## What does the code in this PR do / what does it improve?
Trying to tackle #67. Transplanted straxen PR [Fixing hitlets boundary out of chunk](https://github.com/XENONnT/straxen/pull/1328) and [Copy time of hitlets before clip it](https://github.com/XENONnT/straxen/pull/1338).

## Can you briefly describe how it works?

## Can you give a minimal working example (or illustrate with a figure)?

_Please include the following if applicable:_
  - [x] _Add an appropriate tag to this PR_
  - [ ] _Update the docstring(s)_
  - [ ] _Update the documentation_
  - [ ] _Tests to check the (new) code is working as desired._
  - [ ] _Does it solve one of the open issues on github?_

### _Notes on testing_
 - _Until the automated tests pass, please mark the PR as a draft._
 - _On the XENONnT fork we test with database access, on private forks there is no database access for security considerations._

All _italic_ comments can be removed from this template.
