### PR TITLE
Skip records and tune SE generator

### DIFF
--- a/jobs/config.ini
+++ b/jobs/config.ini
@@ -16,6 +16,7 @@ generator_name = flat
 recoil = 8
 mode = all
 process_data = False
+process_simu = True
 skip_records = True
 delete_records = True
 storage_to_patch = /project/lgrandi/yuanlq/salt/raw_records,/scratch/midway3/yuanlq/salt/raw_records

--- a/jobs/config.ini
+++ b/jobs/config.ini
@@ -16,6 +16,8 @@ generator_name = flat
 recoil = 8
 mode = all
 process_data = False
+skip_records = True
+delete_records = True
 storage_to_patch = /project/lgrandi/yuanlq/salt/raw_records,/scratch/midway3/yuanlq/salt/raw_records
 
 [slurm]

--- a/jobs/job.py
+++ b/jobs/job.py
@@ -15,7 +15,7 @@ strrunid = str(runid).zfill(6)
 
 config = configparser.ConfigParser()
 config.read('config.ini')
-output_folder = config.get('job', 'output_folder')
+output_folder = str(config.get('job', 'output_folder'))
 saltax_mode = config.get('job', 'saltax_mode')
 faxconf_version = config.get('job', 'faxconf_version')
 generator_name = config.get('job', 'generator_name')
@@ -66,7 +66,7 @@ print("Finished making all the computation for run %d in \
 	saltax mode salt. "%(runid))
 if delete_records:
 	print("Deleting records.")
-	records_name = st.key_for('records')
+	records_name = str(st.key_for(strrunid, 'records'))
 	records_path = os.path.join(output_folder, records_name)
 	if os.path.exists(records_path):
 		os.rmdir(records_path)
@@ -107,7 +107,7 @@ if saltax_mode == 'salt':
 			saltax mode data. "%(runid))
 		if delete_records:
 			print("Deleting records.")
-			records_name = st.key_for('records')
+			records_name = str(st.key_for(strrunid, 'records'))
 			records_path = os.path.join(output_folder, records_name)
 			if os.path.exists(records_path):
 				os.rmdir(records_path)
@@ -149,7 +149,7 @@ if saltax_mode == 'salt':
 			saltax mode simu. "%(runid))
 		if delete_records:
 			print("Deleting records.")
-			records_name = st.key_for('records')
+			records_name = str(st.key_for(strrunid, 'records'))
 			records_path = os.path.join(output_folder, records_name)
 			if os.path.exists(records_path):
 				os.rmdir(records_path)

--- a/jobs/job.py
+++ b/jobs/job.py
@@ -21,6 +21,7 @@ generator_name = config.get('job', 'generator_name')
 recoil = config.getint('job', 'recoil')
 mode = config.get('job', 'mode')
 process_data = config.getboolean('job', 'process_data')
+process_simu = config.getboolean('job', 'process_simu')
 storage_to_patch = config.get('job', 'storage_to_patch').split(',')
 
 to_process_dtypes = ['records', 'peaklets', 'merged_s2s', 'peak_basics',
@@ -88,29 +89,32 @@ if saltax_mode == 'salt':
 	else:
 		print("You specified process_data = False, so we will not process data.")
 		
-	st = saltax.contexts.sxenonnt(runid = runid,
-                                  saltax_mode = 'simu',
-                                  output_folder = output_folder,
-                                  faxconf_version = faxconf_version,
-                                  generator_name = generator_name,
-                                  recoil = recoil,
-                                  mode = mode)
-	if len(storage_to_patch) and storage_to_patch[0] != "":
-		for d in st.storage:
-			st.storage.append(strax.DataDirectory(d, readonly=True))
-			
-	st.make(strrunid, 'raw_records_simu')
-	gc.collect()
-	for dt in to_process_dtypes:
-		print("Making %s. "%dt)
-		st.make(strrunid, dt, save=(dt))
-		print("Done with %s. "%dt)
+	if process_simu:
+		st = saltax.contexts.sxenonnt(runid = runid,
+									saltax_mode = 'simu',
+									output_folder = output_folder,
+									faxconf_version = faxconf_version,
+									generator_name = generator_name,
+									recoil = recoil,
+									mode = mode)
+		if len(storage_to_patch) and storage_to_patch[0] != "":
+			for d in st.storage:
+				st.storage.append(strax.DataDirectory(d, readonly=True))
+				
+		st.make(strrunid, 'raw_records_simu')
 		gc.collect()
+		for dt in to_process_dtypes:
+			print("Making %s. "%dt)
+			st.make(strrunid, dt, save=(dt))
+			print("Done with %s. "%dt)
+			gc.collect()
 
-	print("Used time:", datetime.now() - now)
-	now = datetime.now()
+		print("Used time:", datetime.now() - now)
+		now = datetime.now()
 
-	print("Finished making all the computation for run %d in \
-           saltax mode %s. "%(runid, 'simu'))
+		print("Finished making all the computation for run %d in \
+			saltax mode %s. "%(runid, 'simu'))
+	else:
+		print("You specified process_simu = False, so we will not process simu.")
 
 print("Finished all. Exiting.")

--- a/jobs/job.py
+++ b/jobs/job.py
@@ -37,6 +37,7 @@ if not skip_records:
 print("Used time:", datetime.now() - now)
 now = datetime.now()
 
+print('====================')
 print("Finished importing and config loading, now start to load context.")
 print("Now starting %s context for run %d"%(saltax_mode, runid))
 st = saltax.contexts.sxenonnt(runid = runid,
@@ -71,12 +72,14 @@ if delete_records:
 		os.rmdir(records_path)
 		gc.collect()
 		print("Deleted records for run %d in saltax mode salt. "%(runid))
+print('====================')
+
 
 if saltax_mode == 'salt':
-	print("Since you specified saltax_mode = salt, \
-           we will also compute simulation-only and data-only.")
-
 	if process_data:
+		print('====================')
+		print("Since you specified saltax_mode = salt, \
+          	   we will also compute simulation-only and data-only.")
 		print("Now starting data-only context for run %d"%(runid))
 		st = saltax.contexts.sxenonnt(runid = runid, saltax_mode = 'data', 
 									  output_folder = output_folder, 
@@ -110,10 +113,13 @@ if saltax_mode == 'salt':
 				os.rmdir(records_path)
 				gc.collect()
 				print("Deleted records for run %d in saltax mode data. "%(runid))
+		print('====================')
 	else:
 		print("You specified process_data = False, so we will not process data.")
 		
 	if process_simu:
+		print('====================')
+		print("Now starting simu-only context for run %d"%(runid))
 		st = saltax.contexts.sxenonnt(runid = runid,
 									saltax_mode = 'simu',
 									output_folder = output_folder,
@@ -149,6 +155,7 @@ if saltax_mode == 'salt':
 				os.rmdir(records_path)
 				gc.collect()
 				print("Deleted records for run %d in saltax mode simu. "%(runid))
+		print('====================')
 	else:
 		print("You specified process_simu = False, so we will not process simu.")
 

--- a/jobs/job.py
+++ b/jobs/job.py
@@ -5,6 +5,7 @@ import configparser
 from datetime import datetime
 import sys
 import gc
+import os
 straxen.print_versions()
 
 now = datetime.now()
@@ -22,12 +23,16 @@ recoil = config.getint('job', 'recoil')
 mode = config.get('job', 'mode')
 process_data = config.getboolean('job', 'process_data')
 process_simu = config.getboolean('job', 'process_simu')
+skip_records = config.getboolean('job', 'skip_records')
 storage_to_patch = config.get('job', 'storage_to_patch').split(',')
+delete_records = config.getboolean('job', 'delete_records')
 
-to_process_dtypes = ['records', 'peaklets', 'merged_s2s', 'peak_basics',
+to_process_dtypes = ['peaklets', 'merged_s2s', 'peak_basics',
 					 'events', 'event_basics', 'event_info', 'event_pattern_fit',
 					 'event_shadow', 'event_ambience', 'event_n_channel','veto_intervals',
 					 'cuts_basic']
+if not skip_records:
+	to_process_dtypes = ['records'] + to_process_dtypes
 
 print("Used time:", datetime.now() - now)
 now = datetime.now()
@@ -57,7 +62,15 @@ print("Used time:", datetime.now() - now)
 now = datetime.now()
 
 print("Finished making all the computation for run %d in \
-       saltax mode %s. "%(runid, saltax_mode))
+	saltax mode salt. "%(runid))
+if delete_records:
+	print("Deleting records.")
+	records_name = st.key_for('records')
+	records_path = os.path.join(output_folder, records_name)
+	if os.path.exists(records_path):
+		os.rmdir(records_path)
+		gc.collect()
+		print("Deleted records for run %d in saltax mode salt. "%(runid))
 
 if saltax_mode == 'salt':
 	print("Since you specified saltax_mode = salt, \
@@ -86,6 +99,17 @@ if saltax_mode == 'salt':
 
 		print("Finished making all the computation for run %d in \
 			saltax mode %s. "%(runid, 'data'))
+
+		print("Finished making all the computation for run %d in \
+			saltax mode data. "%(runid))
+		if delete_records:
+			print("Deleting records.")
+			records_name = st.key_for('records')
+			records_path = os.path.join(output_folder, records_name)
+			if os.path.exists(records_path):
+				os.rmdir(records_path)
+				gc.collect()
+				print("Deleted records for run %d in saltax mode data. "%(runid))
 	else:
 		print("You specified process_data = False, so we will not process data.")
 		
@@ -114,6 +138,17 @@ if saltax_mode == 'salt':
 
 		print("Finished making all the computation for run %d in \
 			saltax mode %s. "%(runid, 'simu'))
+
+		print("Finished making all the computation for run %d in \
+			saltax mode simu. "%(runid))
+		if delete_records:
+			print("Deleting records.")
+			records_name = st.key_for('records')
+			records_path = os.path.join(output_folder, records_name)
+			if os.path.exists(records_path):
+				os.rmdir(records_path)
+				gc.collect()
+				print("Deleted records for run %d in saltax mode simu. "%(runid))
 	else:
 		print("You specified process_simu = False, so we will not process simu.")
 

--- a/saltax/instructions/generator.py
+++ b/saltax/instructions/generator.py
@@ -157,7 +157,7 @@ def instr_file_name(runid, instr, recoil, generator_name, mode, rate=1e9/SALT_TI
     return filename
 
 def generator_se(runid, 
-                 n_tot=None, rate=1e9/SALT_TIME_INTERVAL, 
+                 n_tot=None, rate=1e10/SALT_TIME_INTERVAL, 
                  r_range=R_RANGE, z_range=Z_RANGE, 
                  time_mode="uniform", *args):
     """
@@ -193,7 +193,7 @@ def generator_se(runid,
         
     return instr
 
-def generator_flat(runid, en_range=(0.2, 15.0), recoil=7,
+def generator_flat(runid, en_range=(0.2, 15.0), recoil=8,
                    n_tot=None, rate=1e9/SALT_TIME_INTERVAL, 
                    fmap=FIELD_MAP, nc=NC, 
                    r_range=R_RANGE, z_range=Z_RANGE, 


### PR DESCRIPTION
_Before you submit this PR: make sure to put all operations-related information in a wiki-note, a PR should be about code and is publicly accessible_

## What does the code in this PR do / what does it improve?
- More options in job config to make records skipped and delete them after computation finished to save sapce
- more options to turn off simulation computation
- tunned SE generator default rate

## Can you briefly describe how it works?

## Can you give a minimal working example (or illustrate with a figure)?

_Please include the following if applicable:_
  - [ ] _Add an appropriate tag to this PR_
  - [ ] _Update the docstring(s)_
  - [ ] _Update the documentation_
  - [ ] _Tests to check the (new) code is working as desired._
  - [ ] _Does it solve one of the open issues on github?_

### _Notes on testing_
 - _Until the automated tests pass, please mark the PR as a draft._
 - _On the XENONnT fork we test with database access, on private forks there is no database access for security considerations._

All _italic_ comments can be removed from this template.
