### PR TITLE
Debug Infinite `lone_hits` area in `merged_s2s`

### DIFF
--- a/saltax/plugins/s_peaklets.py
+++ b/saltax/plugins/s_peaklets.py
@@ -307,6 +307,7 @@ class SPeaklets(strax.Plugin):
             n_top_channels=n_top_pmts_if_digitize_top
         )
 
+        # FIXME: Saturation correction in salt mode is nonsense
         # Saturation correction using non-saturated channels
         # similar method used in pax
         # see https://github.com/XENON1T/pax/pull/712

--- a/saltax/plugins/s_peaklets.py
+++ b/saltax/plugins/s_peaklets.py
@@ -215,6 +215,8 @@ class SPeaklets(strax.Plugin):
 
         # Remove hits in zero-gain channels
         # they should not affect the clustering!
+        # NB: we tried to shift hit channel here, but will lead to significant troubles because of overlapping
+        # hit timing between the simu and data channels in many cases
         hits = hits[self.to_pe[hits['channel']] != 0]
 
         hits = strax.sort_by_time(hits)

--- a/saltax/plugins/s_peaklets.py
+++ b/saltax/plugins/s_peaklets.py
@@ -689,6 +689,7 @@ def find_peaks(hits, adc_to_pe,
         peak_endtime = max(peak_endtime, t1)
         hit_area_pe = hit['area'] * adc_to_pe[hit['channel']]
         
+        # FIXME: surgery here; top/bot array related
         # Manually shift channels for area_per_channel
         if hit['channel']>=SCHANNEL_STARTS_AT:
             area_per_channel[hit['channel']-SCHANNEL_STARTS_AT] += hit_area_pe

--- a/saltax/plugins/s_peaklets.py
+++ b/saltax/plugins/s_peaklets.py
@@ -45,7 +45,7 @@ class SPeaklets(strax.Plugin):
     parallel = 'process'
     compressor = 'zstd'
 
-    __version__ = '0.0.3'
+    __version__ = '0.0.4'
 
     peaklet_gap_threshold = straxen.URLConfig(
         default=700, infer_type=False,

--- a/saltax/plugins/s_peaklets.py
+++ b/saltax/plugins/s_peaklets.py
@@ -378,6 +378,9 @@ class SPeaklets(strax.Plugin):
             raise ValueError(
                 f'Found n_hits less than tight_coincidence')
 
+        # FIXME: surgery here; shifted lone_hits' channel
+        lone_hits['channel'] = lone_hits['channel'] - SCHANNEL_STARTS_AT
+
         return dict(peaklets=peaklets,
                     lone_hits=lone_hits)
 

--- a/saltax/plugins/s_peaklets.py
+++ b/saltax/plugins/s_peaklets.py
@@ -198,7 +198,7 @@ class SPeaklets(strax.Plugin):
         setattr(strax, "sum_waveform", sum_waveform_salted)
         
     def compute(self, records, start, end):
-        # FIXME: This is screwing up the record_i in data or simu mode!
+        # FIXME: This is going to make the same lone hit having different record_i, between in salt mode and others
         # FIXME: surgery here; channel specification related
         # Based on saltax_mode, determine what channels to involve
         if self.config['saltax_mode'] == 'salt':

--- a/saltax/plugins/s_peaklets.py
+++ b/saltax/plugins/s_peaklets.py
@@ -246,6 +246,9 @@ class SPeaklets(strax.Plugin):
         is_lone_hit = strax.fully_contained_in(hits, peaklets) == -1
         lone_hits = hits[is_lone_hit]
 
+        # FIXME: surgery here; shifted lone_hits' channel
+        lone_hits['channel'] = lone_hits['channel'] - SCHANNEL_STARTS_AT
+
         # Update the area of lone_hits to the integral in ADCcounts x samples
         strax.integrate_lone_hits(
             lone_hits, records, peaklets,

--- a/saltax/plugins/s_peaklets.py
+++ b/saltax/plugins/s_peaklets.py
@@ -198,6 +198,8 @@ class SPeaklets(strax.Plugin):
         setattr(strax, "sum_waveform", sum_waveform_salted)
         
     def compute(self, records, start, end):
+        # FIXME: This is screwing up the record_i in data or simu mode!
+        # FIXME: surgery here; channel specification related
         # Based on saltax_mode, determine what channels to involve
         if self.config['saltax_mode'] == 'salt':
             records = records[(records['channel']>=SCHANNEL_STARTS_AT)|

--- a/saltax/plugins/s_peaklets.py
+++ b/saltax/plugins/s_peaklets.py
@@ -215,8 +215,8 @@ class SPeaklets(strax.Plugin):
 
         # Remove hits in zero-gain channels
         # they should not affect the clustering!
-        # NB: we tried to shift hit channel here, but will lead to significant troubles because of overlapping
-        # hit timing between the simu and data channels in many cases
+        # NB: it's attempting to shift hit channel here, but will lead to significant troubles when summing waveforms,
+        # because the 988-channel number is still requred when reading records_i data.
         hits = hits[self.to_pe[hits['channel']] != 0]
 
         hits = strax.sort_by_time(hits)
@@ -245,9 +245,6 @@ class SPeaklets(strax.Plugin):
         # which is asserted inside strax.find_peaks.
         is_lone_hit = strax.fully_contained_in(hits, peaklets) == -1
         lone_hits = hits[is_lone_hit]
-
-        # FIXME: surgery here; shifted lone_hits' channel
-        lone_hits['channel'] = lone_hits['channel'] - SCHANNEL_STARTS_AT
 
         # Update the area of lone_hits to the integral in ADCcounts x samples
         strax.integrate_lone_hits(


### PR DESCRIPTION
_Before you submit this PR: make sure to put all operations-related information in a wiki-note, a PR should be about code and is publicly accessible_

## What does the code in this PR do / what does it improve?
Currently there are some waveforms like this, which gives infinite `merged_s2s` area as well as a bad point in data. See this

![image](https://github.com/FaroutYLq/saltax/assets/47046530/01274d9f-4971-4b1a-ad08-a4e078bd0c82)

The root of this issue is suspected to lie in the absence of `lone_hits` channel shifting. Without it, in `merged_s2s` when adding `lone_hits` [here](https://github.com/AxFoundation/strax/blob/93e4a093c6d8788821e91a9d4631bd60e0dfd81f/strax/processing/peak_merging.py#L189-L197) by sealing `to_pe` like [this](https://github.com/XENONnT/straxen/blob/fb1ae7681eb743854adfcb252094a86d4ef973f0/straxen/plugins/merged_s2s/merged_s2s.py#L70), we may have a bad point with value `np.inf`. It is not clear why it is infinite, but maybe just some black magic in numba.

## Can you briefly describe how it works?
Just shift back the channel numbers for `lone_hits` at the end of `SPeaklets`.

## Can you give a minimal working example (or illustrate with a figure)?
No I didn't test it. Will try again once we recomputed.

_Please include the following if applicable:_
  - [x] _Add an appropriate tag to this PR_
  - [x] _Update the docstring(s)_
  - [ ] _Update the documentation_
  - [ ] _Tests to check the (new) code is working as desired._
  - [ ] _Does it solve one of the open issues on github?_

### _Notes on testing_
 - _Until the automated tests pass, please mark the PR as a draft._
 - _On the XENONnT fork we test with database access, on private forks there is no database access for security considerations._

All _italic_ comments can be removed from this template.
