### PR TITLE
Increased default salting rate and avoid regenerating instructions

### DIFF
--- a/jobs/job.py
+++ b/jobs/job.py
@@ -64,12 +64,12 @@ if len(storage_to_patch) and storage_to_patch[0] != "":
 	for d in storage_to_patch:
 		st.storage.append(strax.DataDirectory(d, readonly=True))
 
-st.make(strrunid, 'raw_records_simu')
+st.make(strrunid, 'raw_records_simu', progress_bar=True)
 gc.collect()
 for dt in to_process_dtypes:
 	print("Making %s. "%dt)
 	try:
-		st.make(strrunid, dt, save=(dt))
+		st.make(strrunid, dt, save=(dt), progress_bar=True)
 		print("Done with %s. "%dt)
 	except NotImplementedError as e:
 		print("The cut_basics for run %d is not implemented. "%runid)
@@ -100,7 +100,7 @@ if saltax_mode == 'salt':
 		for dt in to_process_dtypes:
 			print("Making %s. "%dt)
 			try:
-				st.make(strrunid, dt, save=(dt))
+				st.make(strrunid, dt, save=(dt), progress_bar=True)
 				print("Done with %s. "%dt)
 			except NotImplementedError as e:
 				print("The cut_basics for run %d is not implemented. "%runid)
@@ -133,13 +133,13 @@ if saltax_mode == 'salt':
 			print("Making %s. "%dt)
 
 			try:
-				st.make(strrunid, dt, save=(dt))
+				st.make(strrunid, dt, save=(dt), progress_bar=True)
 				print("Done with %s. "%dt)
 			except NotImplementedError as e:
 				print("The cut_basics for run %d is not implemented. "%runid)
 			gc.collect()
 		# Manually make pema plugin after
-		st.make(strrunid, 'match_acceptance_extended')
+		st.make(strrunid, 'match_acceptance_extended', progress_bar=True)
 
 		print("Used time:", datetime.now() - now)
 		now = datetime.now()

--- a/saltax/contexts.py
+++ b/saltax/contexts.py
@@ -60,7 +60,7 @@ def get_generator(generator_name):
     generator_func = eval('saltax.generator_'+generator_name)
     return generator_func
 
-def xenonnt_salted(runid, 
+def xenonnt_salted(runid=51906, 
                    saltax_mode='salt',
                    output_folder='./strax_data',
                    xedocs_version=DEFAULT_XEDOCS_VERSION,
@@ -76,7 +76,9 @@ def xenonnt_salted(runid,
                    **kwargs):
     """
     Return a strax context for XENONnT data analysis with saltax.
-    :param runid: run number in integer. Must exist in RunDB.
+    :param runid: run number in integer. Must exist in RunDB, defaults to 51906 as a place holder. 
+        Note that it doesn't matter when you are loading computed run, but only matter when 
+        you use the context to compute new runs.
     :param saltax_mode: 'data', 'simu', or 'salt'.
     :param output_folder: Directory where data will be stored, defaults to ./strax_data
     :param xedocs_version: XENONnT documentation version to use, defaults to DEFAULT_XEDOCS_VERSION

--- a/saltax/contexts.py
+++ b/saltax/contexts.py
@@ -235,6 +235,8 @@ def sxenonnt(runid=None,
     if runid is None:
         print("Since you specified runid=None, this context will not be able to compute raw_records_simu.")
         print("Welcome to data-loading only mode!")
+    else:
+        print("Welcome to computation mode which only works for run %s!"%(runid))
 
     return xenonnt_salted(
         runid=runid,

--- a/saltax/contexts.py
+++ b/saltax/contexts.py
@@ -76,9 +76,8 @@ def xenonnt_salted(runid=None,
                    **kwargs):
     """
     Return a strax context for XENONnT data analysis with saltax.
-    :param runid: run number in integer. Must exist in RunDB, defaults to None as data-loading only. 
-        Note that it doesn't matter when you are loading computed run, but only matter when 
-        you use the context to compute new runs.
+    :param runid: run number in integer. Must exist in RunDB if you use this context to 
+        compute raw_records_simu, or use None for data-loading only.
     :param saltax_mode: 'data', 'simu', or 'salt'.
     :param output_folder: Directory where data will be stored, defaults to ./strax_data
     :param xedocs_version: XENONnT documentation version to use, defaults to DEFAULT_XEDOCS_VERSION
@@ -216,7 +215,8 @@ def sxenonnt(runid=None,
              **kwargs):
     """
     United strax context for XENONnT data, simulation, or salted data.
-    :param runid: run number in integer. Must exist in RunDB.
+    :param runid: run number in integer. Must exist in RunDB if you use this context to 
+        compute raw_records_simu, or use None for data-loading only.
     :param saltax_mode: 'data', 'simu', or 'salt'
     :param output_folder: Output folder for strax data, default './strax_data'
     :param xedocs_version: xedocs version to use, default is synced with cutax latest
@@ -232,6 +232,9 @@ def sxenonnt(runid=None,
     :return: strax context
     """
     assert saltax_mode in SALTAX_MODES, "saltax_mode must be one of %s"%(SALTAX_MODES)
+    if runid is None:
+        print("Since you specified runid=None, this context will not be able to compute raw_records_simu.")
+        print("Welcome to data-loading only mode!")
 
     return xenonnt_salted(
         runid=runid,

--- a/saltax/instructions/generator.py
+++ b/saltax/instructions/generator.py
@@ -172,7 +172,7 @@ def instr_file_name(runid, recoil, generator_name, mode, rate=1e9/SALT_TIME_INTE
 def generator_se(runid, 
                  n_tot=None, rate=1e9/SALT_TIME_INTERVAL, 
                  r_range=R_RANGE, z_range=Z_RANGE, 
-                 time_mode="uniform", *args):
+                 time_mode="uniform"):
     """
     Generate instructions for a run with single electron.
     :param runid: run number in integer

--- a/saltax/instructions/generator.py
+++ b/saltax/instructions/generator.py
@@ -145,10 +145,10 @@ def get_run_start_end(runid):
     
     return unix_time_start_ns, unix_time_end_ns
 
-def instr_file_name(runid, instr, recoil, generator_name, mode, rate=1e9/SALT_TIME_INTERVAL,
+def instr_file_name(runid, recoil, generator_name, mode, rate=1e9/SALT_TIME_INTERVAL,
                     base_dir=BASE_DIR):
     """
-    Generate the instruction file name and then save the csv instructions.
+    Generate the instruction file name based on the runid, recoil, generator_name, mode, and rate.
     :param runid: run number in integer
     :param instr: instructions in numpy array
     :param recoil: NEST recoil type
@@ -166,14 +166,6 @@ def instr_file_name(runid, instr, recoil, generator_name, mode, rate=1e9/SALT_TI
     runid = str(runid).zfill(6)
     filename = BASE_DIR + runid + "-" + str(recoil) + "-" + \
         generator_name + "-" + mode + "-" + str(rate) + ".csv"
-    
-    # if the file already exists, we don't want to overwrite it
-    if not os.path.exists(filename):
-        pd.DataFrame(instr).to_csv(filename, index=False)
-    else:
-        print("Instruction file already exists at: %s" % (filename))
-        
-    print("Instruction file at: %s" % (filename))
 
     return filename
 

--- a/saltax/instructions/generator.py
+++ b/saltax/instructions/generator.py
@@ -9,6 +9,7 @@ from utilix import xent_collection
 import datetime
 import os
 import pickle
+from tqdm import tqdm
 
 
 SALT_TIME_INTERVAL = 1e7 # in unit of ns. The number should be way bigger then full drift time
@@ -290,7 +291,7 @@ def generator_ambe(runid,
 
     instr = np.zeros(0, dtype=wfsim.instruction_dtype)
     # assign instructions
-    for i in range(n_tot):
+    for i in tqdm(range(n_tot)):
         # bootstrapped ambe instruction
         selected_ambe = ambe_instructions[ambe_instructions['event_number'] 
                                           == ambe_event_numbers[i]]

--- a/saltax/instructions/generator.py
+++ b/saltax/instructions/generator.py
@@ -11,7 +11,7 @@ import os
 import pickle
 
 
-SALT_TIME_INTERVAL = 5e7 # in unit of ns. The number should be way bigger then full drift time
+SALT_TIME_INTERVAL = 1e7 # in unit of ns. The number should be way bigger then full drift time
 Z_RANGE = (-148.15, 0) # in unit of cm
 R_RANGE = (0, 66.4) # in unit of cm
 DOWNLOADER = straxen.MongoDownloader()

--- a/saltax/instructions/generator.py
+++ b/saltax/instructions/generator.py
@@ -145,29 +145,34 @@ def get_run_start_end(runid):
     
     return unix_time_start_ns, unix_time_end_ns
 
-def instr_file_name(runid, recoil, generator_name, mode, rate=1e9/SALT_TIME_INTERVAL,
+def instr_file_name(recoil, generator_name, mode, runid=None,
+                    rate=1e9/SALT_TIME_INTERVAL,
                     base_dir=BASE_DIR):
     """
     Generate the instruction file name based on the runid, recoil, generator_name, mode, and rate.
-    :param runid: run number in integer
-    :param instr: instructions in numpy array
     :param recoil: NEST recoil type
     :param generator_name: name of the generator
     :param mode: 's1', 's2', or 'all'
+    :param runid: run number in integer, default: None, which means we are loading data and instruction 
+        doesn't matter (strax lineage unaffected)
     :param rate: rate of events in Hz
     :param base_dir: base directory to save the instruction file, default: BASE_DIR
     :return: instruction file name
     """
+    if runid is None:
+        return "Data-loading only, no instruction file needed."
+    
     # FIXME: this will shoot errors if we are on OSG rather than midway
-    if base_dir[-1] != '/':
-        base_dir += '/'
+    else:
+        if base_dir[-1] != '/':
+            base_dir += '/'
 
-    rate = int(rate)
-    runid = str(runid).zfill(6)
-    filename = BASE_DIR + runid + "-" + str(recoil) + "-" + \
-        generator_name + "-" + mode + "-" + str(rate) + ".csv"
+        rate = int(rate)
+        runid = str(runid).zfill(6)
+        filename = BASE_DIR + runid + "-" + str(recoil) + "-" + \
+            generator_name + "-" + mode + "-" + str(rate) + ".csv"
 
-    return filename
+        return filename
 
 def generator_se(runid, 
                  n_tot=None, rate=1e9/SALT_TIME_INTERVAL, 


### PR DESCRIPTION
_Before you submit this PR: make sure to put all operations-related information in a wiki-note, a PR should be about code and is publicly accessible_

## What does the code in this PR do / what does it improve?
- Increased default salting rate
- avoid regenerating instructions.
- Added a bit more debugging friendly info

## Can you briefly describe how it works?
For avoiding regenerating instructions, we require file existence check before generating instruction.

## Can you give a minimal working example (or illustrate with a figure)?

_Please include the following if applicable:_
  - [ ] _Add an appropriate tag to this PR_
  - [ ] _Update the docstring(s)_
  - [ ] _Update the documentation_
  - [ ] _Tests to check the (new) code is working as desired._
  - [ ] _Does it solve one of the open issues on github?_

### _Notes on testing_
 - _Until the automated tests pass, please mark the PR as a draft._
 - _On the XENONnT fork we test with database access, on private forks there is no database access for security considerations._

All _italic_ comments can be removed from this template.
