### PR TITLE
Fixed a fatal bug in `lone_hits` channel shifting

### DIFF
--- a/saltax/contexts.py
+++ b/saltax/contexts.py
@@ -108,7 +108,7 @@ def xenonnt_salted(runid=None,
         except:
             print(f"Instruction file {instr_file_name} not found. Generating instructions...")
             instr = generator_func(runid=runid)
-            instr.to_csv(instr_file_name, index=False)
+            pd.DataFrame(instr).to_csv(instr_file_name, index=False)
             print(f"Instructions saved to {instr_file_name}")
 
     # Based on cutax.xenonnt_sim_base()

--- a/saltax/instructions/generator.py
+++ b/saltax/instructions/generator.py
@@ -12,7 +12,7 @@ import pickle
 from tqdm import tqdm
 
 
-SALT_TIME_INTERVAL = 1e7 # in unit of ns. The number should be way bigger then full drift time
+SALT_TIME_INTERVAL = 2e7 # in unit of ns. The number should be way bigger then full drift time
 Z_RANGE = (-148.15, 0) # in unit of cm
 R_RANGE = (0, 66.4) # in unit of cm
 DOWNLOADER = straxen.MongoDownloader()

--- a/saltax/instructions/generator.py
+++ b/saltax/instructions/generator.py
@@ -283,8 +283,7 @@ def generator_ambe(runid,
 
     # bootstrap instructions
     ambe_instructions = pd.read_csv(ambe_instructions_file)
-    n_avail_instructions = np.max(ambe_instructions.event_number)
-    ambe_event_numbers = np.random.choice(np.arange(n_avail_instructions), 
+    ambe_event_numbers = np.random.choice(np.unique(ambe_instructions.event_number), 
                                           n_tot,
                                           replace=True)
 

--- a/saltax/instructions/generator.py
+++ b/saltax/instructions/generator.py
@@ -287,8 +287,8 @@ def generator_ambe(runid,
                                           n_tot,
                                           replace=True)
 
-    instr = np.zeros(0, dtype=wfsim.instruction_dtype)
     # assign instructions
+    instr = np.zeros(0, dtype=wfsim.instruction_dtype)
     for i in tqdm(range(n_tot)):
         # bootstrapped ambe instruction
         selected_ambe = ambe_instructions[ambe_instructions['event_number'] 

--- a/saltax/plugins/s_peaklets.py
+++ b/saltax/plugins/s_peaklets.py
@@ -381,10 +381,13 @@ class SPeaklets(strax.Plugin):
             raise ValueError(
                 f'Found n_hits less than tight_coincidence')
 
-        # FIXME: surgery here; shifted lone_hits' channel
-        lone_hits['channel'] = lone_hits['channel'] - SCHANNEL_STARTS_AT
+        # FIXME: surgery here; shifted lone_hits' channel for those which were salted
+        mask_salted_lone_hits = lone_hits['channel'] >= SCHANNEL_STARTS_AT
+        lone_hits[mask_salted_lone_hits]['channel'] = (
+            lone_hits[mask_salted_lone_hits]['channel'] - SCHANNEL_STARTS_AT
+        )
         # Sanity check on channels non-negative
-        assert np.all(lone_hits['channel'] >= 0), "Negative channel in lone_hits"
+        assert np.all(lone_hits['channel'] >= 0), "Negative channel number in lone_hits"
         # Sanity check that no lone_hits are in peaklets
         is_still_lone_hit = strax.fully_contained_in(lone_hits, peaklets) == -1
         assert np.all(is_still_lone_hit), "Some lone_hits are in peaklets!?"

--- a/saltax/plugins/s_peaklets.py
+++ b/saltax/plugins/s_peaklets.py
@@ -383,6 +383,8 @@ class SPeaklets(strax.Plugin):
 
         # FIXME: surgery here; shifted lone_hits' channel
         lone_hits['channel'] = lone_hits['channel'] - SCHANNEL_STARTS_AT
+        # Sanity check on channels non-negative
+        assert np.all(lone_hits['channel'] >= 0), "Negative channel in lone_hits"
 
         return dict(peaklets=peaklets,
                     lone_hits=lone_hits)

--- a/saltax/plugins/s_peaklets.py
+++ b/saltax/plugins/s_peaklets.py
@@ -383,9 +383,7 @@ class SPeaklets(strax.Plugin):
 
         # FIXME: surgery here; shifted lone_hits' channel for those which were salted
         mask_salted_lone_hits = lone_hits['channel'] >= SCHANNEL_STARTS_AT
-        lone_hits[mask_salted_lone_hits]['channel'] = (
-            lone_hits[mask_salted_lone_hits]['channel'] - SCHANNEL_STARTS_AT
-        )
+        lone_hits[mask_salted_lone_hits]['channel'] -= SCHANNEL_STARTS_AT
         # Sanity check on channels non-negative
         assert np.all(lone_hits['channel'] >= 0), "Negative channel number in lone_hits"
         # Sanity check that no lone_hits are in peaklets

--- a/saltax/plugins/s_peaklets.py
+++ b/saltax/plugins/s_peaklets.py
@@ -385,6 +385,9 @@ class SPeaklets(strax.Plugin):
         lone_hits['channel'] = lone_hits['channel'] - SCHANNEL_STARTS_AT
         # Sanity check on channels non-negative
         assert np.all(lone_hits['channel'] >= 0), "Negative channel in lone_hits"
+        # Sanity check that no lone_hits are in peaklets
+        is_still_lone_hit = strax.fully_contained_in(lone_hits, peaklets) == -1
+        assert np.all(is_still_lone_hit), "Some lone_hits are in peaklets!?"
 
         return dict(peaklets=peaklets,
                     lone_hits=lone_hits)


### PR DESCRIPTION
- In #85 I introduced a bug for shifting `lone_hits` channel number. I applied the subtraction to every channel, which leads to the fact that the data `lone_hits` will have negative channel. 
- Improved some bad logic in ambe generator, which may lead to selecting an empty instruction to pass.