### PR TITLE
Added safeguard after chunk_start

### DIFF
--- a/jobs/job.py
+++ b/jobs/job.py
@@ -58,6 +58,8 @@ to_process_dtypes_se = [
     "merged_s2s",
     "peak_basics",
     "peak_positions_mlp",
+    "peak_shadow",
+    "peak_ambience",
 ]
 if "se" in generator_name:
     to_process_dtypes = to_process_dtypes_se

--- a/jobs/job.py
+++ b/jobs/job.py
@@ -58,6 +58,8 @@ to_process_dtypes_se = [
     "merged_s2s",
     "peak_basics",
     "peak_positions_mlp",
+    "peak_positions_cnn",
+    "peak_positions_gcn",
     "peak_shadow",
     "peak_ambience",
 ]

--- a/saltax/contexts.py
+++ b/saltax/contexts.py
@@ -102,7 +102,8 @@ def xenonnt_salted(
     :param recoil: (for simulation) NEST recoil type, defaults to 7
         (beta ER)
     :param simu_mode: 's1', 's2', or 'all'. Defaults to 'all'
-    :param kwargs: Extra options to pass to strax.Context or generator, and rate for generator
+    :param kwargs: Extra options to pass to strax.Context or generator,
+        and rate for generator
     :return: strax context
     """
     # Get salt generator

--- a/saltax/match/utils.py
+++ b/saltax/match/utils.py
@@ -319,7 +319,8 @@ def load_events(runs, st_salt, st_simu, plugins=("event_info", "cuts_basic"), **
     :param st_simu: saltax context for simu mode
     :param plugins: plugins to be loaded, default to ('event_info',
         'cuts_basic')
-    :param kwargs: arguments for saltax.match_events, i.e. event_window_fuzz,
+    :param kwargs: arguments for saltax.match_events, i.e.
+        event_window_fuzz,
     :return: events_simu: events from simulated dataset, filtered out
         those who miss S1
     :return: events_salt: events from sprinkled dataset

--- a/saltax/plugins/s_raw_records.py
+++ b/saltax/plugins/s_raw_records.py
@@ -16,7 +16,7 @@ logging.basicConfig(handlers=[logging.StreamHandler()])
 log = logging.getLogger("wfsim.interface")
 log.setLevel("WARNING")
 
-NS_NO_INSTRUCTION_BEFORE_CHUNK_END  = 5e7
+NS_NO_INSTRUCTION_BEFORE_CHUNK_END = 5e7
 NS_NO_INSTRUCTION_AFTER_CHUNK_START = 5e7
 
 

--- a/saltax/plugins/s_raw_records.py
+++ b/saltax/plugins/s_raw_records.py
@@ -16,7 +16,8 @@ logging.basicConfig(handlers=[logging.StreamHandler()])
 log = logging.getLogger("wfsim.interface")
 log.setLevel("WARNING")
 
-NS_NO_INSTRUCTION_BEFORE_CHUNK_END = 5e7
+NS_NO_INSTRUCTION_BEFORE_CHUNK_END  = 5e7
+NS_NO_INSTRUCTION_AFTER_CHUNK_START = 5e7
 
 
 @export
@@ -273,7 +274,7 @@ class SRawRecordsFromFaxNT(SimulatorPlugin):
         self.sim = ChunkRawRecords(self.config)
         instructions = self.instructions
         instructions = instructions[
-            (instructions["time"] >= start)
+            (instructions["time"] >= start + NS_NO_INSTRUCTION_AFTER_CHUNK_START)
             & (instructions["time"] < end - NS_NO_INSTRUCTION_BEFORE_CHUNK_END)
         ]
         self.sim_iter = self.sim(instructions)


### PR DESCRIPTION
- Trying to resolve #105. Just added a hard cut on instructions right after chunk starts. Don't have a good reason, but just to make it the same as in chunk end.
- Added more to-do plugins for SE case, since we want to track shadow and ambience