### PR TITLE
Removed wfsim version requirement

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 strax
 straxen
-git+https://github.com/XENONnT/repository.git@8180bda7a18d7e6c4f4217cfb314154d016fcd10#egg=wfsim
+wfsim
 scipy
 numpy
 pandas


### PR DESCRIPTION
Just to make the installation work. However, it is still wrong because we don't have a 1.2.2 wfsim on pypi. We want to solve it later.