### PR TITLE
Decouple runid from lineage

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,16 @@ cd saltax
 pip install ./ --user
 ```
 ## Tutorial
-Please check notebooks in `notebooks/`
+Please check notebooks in `notebooks/`.
 
 ## Computing
-Please see folder `jobs/` for slurm job submission
+Please see folder `jobs/` for slurm job submission. Below you can see a benchmark from a 26seconds Ar37 run, sprinkled 50Hz flat beta band. You can roughly estimate the overhead by scaling it, neglecting the rate dependence in overhead.
+
+| Step                  | Overhead [sec] (salt) | Overhead [sec] (simu) |
+| :-------------------: | :-------------------: | :-------------------: |
+| `microphysics_summary`| 19                    |                       |
+| `raw_records_simu`    | 210                   |                       |
+| `records`             | 15                    |                       |
+| `peaklets`            | 68                    | 9                     |
+| `peak_basics`         | 3                     | 1                     |
+| `event_info`          | 63                    | 11                    |

--- a/saltax/__init__.py
+++ b/saltax/__init__.py
@@ -1,5 +1,3 @@
-__version__ = "0.1.1"
-
 from . import instructions
 from .instructions import *
 

--- a/saltax/contexts.py
+++ b/saltax/contexts.py
@@ -5,9 +5,9 @@ import strax
 from immutabledict import immutabledict
 import fuse
 import logging
-
-# import pema
 import pandas as pd
+from utilix import xent_collection
+
 
 logging.basicConfig(handlers=[logging.StreamHandler()])
 log = logging.getLogger("fuse.context")
@@ -107,6 +107,18 @@ DEFAULT_XEDOCS_VERSION = cutax.contexts.DEFAULT_XEDOCS_VERSION
 
 # saltax modes supported
 SALTAX_MODES = ["data", "simu", "salt"]
+
+
+def validate_runid(runid):
+    """
+    Validate runid in RunDB to see if you can use it for computation.
+    """
+    try:
+        doc = xent_collection().find_one({"number": runid})
+        if doc is None:
+            raise ValueError(f"Run {runid} not found in RunDB")
+    except Exception as e:
+        raise ValueError(f"Run {runid} not found in RunDB: {e}")
 
 
 def get_generator(generator_name):
@@ -458,6 +470,7 @@ def fxenonnt(
         )
         log.warning("Welcome to data-loading only mode!")
     else:
+        validate_runid(runid)
         log.warning("Welcome to computation mode which only works for run %s!" % (runid))
 
     return xenonnt_salted_fuse(
@@ -527,6 +540,7 @@ def sxenonnt(
         )
         log.warning("Welcome to data-loading only mode!")
     else:
+        validate_runid(runid)
         log.warning("Welcome to computation mode which only works for run %s!" % (runid))
 
     return xenonnt_salted_wfsim(

--- a/saltax/contexts.py
+++ b/saltax/contexts.py
@@ -112,6 +112,9 @@ SALTAX_MODES = ["data", "simu", "salt"]
 def validate_runid(runid):
     """
     Validate runid in RunDB to see if you can use it for computation.
+
+    :param runid: run number in integer
+    :return: None
     """
     try:
         doc = xent_collection().find_one({"number": runid})

--- a/saltax/contexts.py
+++ b/saltax/contexts.py
@@ -46,9 +46,6 @@ FUSE_DONT_REGISTER = [
 # ~Infinite raw_records file size to avoid downchunking
 MAX_RAW_RECORDS_FILE_SIZE_MB = 1e9
 
-# fuse placeholder parameters
-CORRECTION_RUN_ID_DEFAULT = "046477"
-
 # straxen XENONnT options/configuration
 XNT_COMMON_OPTS = straxen.contexts.xnt_common_opts.copy()
 XNT_COMMON_CONFIG = straxen.contexts.xnt_common_config.copy()
@@ -166,11 +163,6 @@ def xenonnt_salted_fuse(
     :param kwargs: Extra options to pass to strax.Context or generator
     :return: strax context
     """
-    # Manually assign a correction_run_id if runid is None
-    if runid is None:
-        corrections_run_id = CORRECTION_RUN_ID_DEFAULT
-    else:
-        corrections_run_id = runid
     if (corrections_version is None) & (not run_without_proper_corrections):
         raise ValueError(
             "Specify a corrections_version. If you want to run without proper "
@@ -208,15 +200,6 @@ def xenonnt_salted_fuse(
 
     simulation_config_file = "fuse_config_nt_{:s}.json".format(simu_config_version)
     fuse.context.set_simulation_config_file(st, simulation_config_file)
-
-    local_versions = st.config
-    for config_name, url_config in local_versions.items():
-        if isinstance(url_config, str):
-            if "run_id" in url_config:
-                local_versions[config_name] = straxen.URLConfig.format_url_kwargs(
-                    url_config, run_id=corrections_run_id
-                )
-    st.config = local_versions
 
     # Update some run specific config
     for mc_config, processing_config in run_id_specific_config.items():

--- a/saltax/instructions/__init__.py
+++ b/saltax/instructions/__init__.py
@@ -1,3 +1,2 @@
-__version__ = "0.1.1"
 from . import generator
 from .generator import *

--- a/saltax/match/__init__.py
+++ b/saltax/match/__init__.py
@@ -1,4 +1,3 @@
-__version__ = "0.1.1"
 from . import match
 from .match import *
 from . import visual

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ setuptools.setup(
     author="Lanqing Yuan",
     description="Salting analysis framework for XENONnT.",
     long_description=readme,
-    version="0.1.1",
+    version="0.1.2",
     install_requires=requires,
     setup_requires=["pytest-runner"],
     tests_require=requires + ["pytest", "hypothesis", "boltons"],


### PR DESCRIPTION
- Bumped version to `v0.1.2`
- Adding runid validation in context
- Removed `corrections_run_id`