### PR TITLE
Include `en_range` in instruction file name

### DIFF
--- a/saltax/instructions/generator.py
+++ b/saltax/instructions/generator.py
@@ -12,7 +12,7 @@ import pickle
 from tqdm import tqdm
 
 
-DEFAULT_EN_RANGE = (0.2,15.0)  # in unit of keV
+DEFAULT_EN_RANGE = (0.2, 15.0)  # in unit of keV
 SALT_TIME_INTERVAL = 2e7  # in unit of ns. The number should be way bigger then full drift time
 Z_RANGE = (-148.15, 0)  # in unit of cm
 R_RANGE = (0, 66.4)  # in unit of cm
@@ -166,7 +166,13 @@ def get_run_start_end(runid):
 
 
 def instr_file_name(
-    recoil, generator_name, mode, runid=None, en_range=DEFAULT_EN_RANGE, rate=1e9 / SALT_TIME_INTERVAL, base_dir=BASE_DIR
+    recoil,
+    generator_name,
+    mode,
+    runid=None,
+    en_range=DEFAULT_EN_RANGE,
+    rate=1e9 / SALT_TIME_INTERVAL,
+    base_dir=BASE_DIR,
 ):
     """Generate the instruction file name based on the runid, recoil,
     generator_name, mode, and rate.

--- a/saltax/instructions/generator.py
+++ b/saltax/instructions/generator.py
@@ -204,7 +204,7 @@ def instr_file_name(
             + "-"
             + generator_name
             + "-"
-            
+            + en_range
             + "-"
             + mode
             + "-"

--- a/saltax/instructions/generator.py
+++ b/saltax/instructions/generator.py
@@ -165,7 +165,7 @@ def get_run_start_end(runid):
 
 
 def instr_file_name(
-    recoil, generator_name, mode, runid=None, rate=1e9 / SALT_TIME_INTERVAL, base_dir=BASE_DIR
+    recoil, generator_name, mode, runid=None, en_range=None, rate=1e9 / SALT_TIME_INTERVAL, base_dir=BASE_DIR
 ):
     """Generate the instruction file name based on the runid, recoil,
     generator_name, mode, and rate.
@@ -176,6 +176,7 @@ def instr_file_name(
     :param runid: run number in integer, default: None, which means we
         are loading data and instruction doesn't matter (strax lineage
         unaffected)
+    :param en_range: (en_min, en_max) in keV, default: None
     :param rate: rate of events in Hz
     :param base_dir: base directory to save the instruction file,
         default: BASE_DIR
@@ -183,6 +184,8 @@ def instr_file_name(
     """
     if runid is None:
         return "Data-loading only, no instruction file needed."
+    if en_range is not None:
+        en_range = str(en_range[0]) + "_" + str(en_range[1])
 
     # FIXME: this will shoot errors if we are on OSG rather than midway
     else:
@@ -198,6 +201,8 @@ def instr_file_name(
             + str(recoil)
             + "-"
             + generator_name
+            + "-"
+            + en_range
             + "-"
             + mode
             + "-"

--- a/saltax/instructions/generator.py
+++ b/saltax/instructions/generator.py
@@ -165,7 +165,7 @@ def get_run_start_end(runid):
 
 
 def instr_file_name(
-    recoil, generator_name, mode, runid=None, en_range=None, rate=1e9 / SALT_TIME_INTERVAL, base_dir=BASE_DIR
+    recoil, generator_name, mode, runid=None, en_range=(0,0), rate=1e9 / SALT_TIME_INTERVAL, base_dir=BASE_DIR
 ):
     """Generate the instruction file name based on the runid, recoil,
     generator_name, mode, and rate.
@@ -182,12 +182,13 @@ def instr_file_name(
         default: BASE_DIR
     :return: instruction file name
     """
-    if runid is None:
-        return "Data-loading only, no instruction file needed."
     if en_range is not None:
         en_range = str(en_range[0]) + "_" + str(en_range[1])
-
+    else:
+        raise RuntimeError("en_range must be specified, and it can even be placeholder (0,0)")
     # FIXME: this will shoot errors if we are on OSG rather than midway
+    if runid is None:
+        return "Data-loading only, no instruction file needed."
     else:
         if base_dir[-1] != "/":
             base_dir += "/"
@@ -202,7 +203,7 @@ def instr_file_name(
             + "-"
             + generator_name
             + "-"
-            + en_range
+            
             + "-"
             + mode
             + "-"

--- a/saltax/instructions/generator.py
+++ b/saltax/instructions/generator.py
@@ -12,6 +12,7 @@ import pickle
 from tqdm import tqdm
 
 
+DEFAULT_EN_RANGE = (0.2,15.0)  # in unit of keV
 SALT_TIME_INTERVAL = 2e7  # in unit of ns. The number should be way bigger then full drift time
 Z_RANGE = (-148.15, 0)  # in unit of cm
 R_RANGE = (0, 66.4)  # in unit of cm
@@ -165,7 +166,7 @@ def get_run_start_end(runid):
 
 
 def instr_file_name(
-    recoil, generator_name, mode, runid=None, en_range=(0,0), rate=1e9 / SALT_TIME_INTERVAL, base_dir=BASE_DIR
+    recoil, generator_name, mode, runid=None, en_range=DEFAULT_EN_RANGE, rate=1e9 / SALT_TIME_INTERVAL, base_dir=BASE_DIR
 ):
     """Generate the instruction file name based on the runid, recoil,
     generator_name, mode, and rate.
@@ -176,7 +177,7 @@ def instr_file_name(
     :param runid: run number in integer, default: None, which means we
         are loading data and instruction doesn't matter (strax lineage
         unaffected)
-    :param en_range: (en_min, en_max) in keV, default: None
+    :param en_range: (en_min, en_max) in keV, default: DEFAULT_EN_RANGE as a placeholder
     :param rate: rate of events in Hz
     :param base_dir: base directory to save the instruction file,
         default: BASE_DIR
@@ -376,7 +377,7 @@ def generator_ambe(
 
 def generator_flat(
     runid,
-    en_range=(0.2, 15.0),
+    en_range=DEFAULT_EN_RANGE,
     recoil=8,
     n_tot=None,
     rate=1e9 / SALT_TIME_INTERVAL,


### PR DESCRIPTION
So that we won't have file name conflict problem for same generator with different energy.